### PR TITLE
CRPP File Save Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ UpgradeLog*.htm
 /ProjectTracker/*
 /DataTracker/js/config.js
 DataTracker/js/config.js
+
+# exclude the TestingProject directory
+/TestingProject/*
+
+# exclude the .vs directory
+/.vs/*

--- a/services/Controllers/DatastoreController.cs
+++ b/services/Controllers/DatastoreController.cs
@@ -2523,7 +2523,8 @@ namespace services.Controllers
                     // Get yesterday's date.
                     DateTime dtYesterday = DateTime.Now.AddDays(-1);
 
-                    foreach (string filePath in filepaths)
+                    // Turning this off for now; it deletes ALL files in the folder with a date older than today.
+                    /*foreach (string filePath in filepaths)
                     {
                         try
                         {
@@ -2546,7 +2547,7 @@ namespace services.Controllers
                             logger.Debug("Inner Exception Message:  " + ioException.InnerException.Message);
                         }
                     }
-                    
+                    */
 
                     // Now let's continue with our save process.
                     //string strSubprojectsPath = root + "\\" + spId;

--- a/services/Properties/PublishProfiles/gisweb02-production.pubxml
+++ b/services/Properties/PublishProfiles/gisweb02-production.pubxml
@@ -11,7 +11,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
-    <publishUrl>x:\dnr\services</publishUrl>
+    <publishUrl>\\gis-web02\Websites\dnr\services</publishUrl>
     <DeleteExistingFiles>False</DeleteExistingFiles>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
During the file process of saving a Correspondence Event, the system was doing some cleanup.  This fix stops that cleanup, so that is does not happen.